### PR TITLE
[RFC] Clean up empty wav files

### DIFF
--- a/apps/receiver.py
+++ b/apps/receiver.py
@@ -73,10 +73,6 @@ class BaseTuner(gr.hier_block2):
             self.file_name == '/dev/null'):
             return
 
-        with open('/tmp/test', 'a') as inp:
-            inp.write(str(self.file_name) + ' ')
-            inp.write(str(os.stat(self.file_name).st_size) + '\n')
-
         # If we never wrote any data to the wavfile sink, delete
         # the (empty) wavfile
         if os.stat(self.file_name).st_size in (44, 0):   # ugly hack


### PR DESCRIPTION
I also moved some base tuner code into the "BaseTuner" class to avoid code duplication.

This should avoid a massive proliferation of 44-byte wav files. Maybe I've got something configured wrong that's causing these? I'm not super happy with the approach I took to determine if a wavfile should be deleted - if it's size 0 or 44, it's either completely empty, or just a header, and should be trashed.

Thoughts?
