### PR TITLE
Feature for review:  Enter center frequency via user interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Example of reading from an IQ file:
 
 `l = Clear lockouts`
 
+`/ = Frequency entry mode (Esc to exit)`
+
 `CTRL-C = quit`
 
 ## Help Menu

--- a/apps/cursesgui.py
+++ b/apps/cursesgui.py
@@ -459,7 +459,7 @@ class RxWindow(object):
             # set mode to frequency entry
             self.freq_entry = ''
             return True
-        elif keyb == 27:
+        elif keyb == 27:  # ESC
             # end frequncy entry mode without seting the frequency
             self.freq_entry = 'None'
             return True
@@ -475,7 +475,7 @@ class RxWindow(object):
             # build up frequency from 1-9 and '.'
             self.freq_entry = self.freq_entry + chr(keyb)
             return True
-        elif keyb == 127:
+        elif keyb == 127:  # BKSP
             self.freq_entry = self.freq_entry[:-1]
             return True
         else:

--- a/apps/cursesgui.py
+++ b/apps/cursesgui.py
@@ -326,6 +326,7 @@ class RxWindow(object):
         # Set default values
         self.center_freq = 146E6
         self.samp_rate = 2E6
+        self.freq_entry = 'None'
         self.gain_db = 0
         self.if_gain_db = 16
         self.bb_gain_db = 16
@@ -379,7 +380,10 @@ class RxWindow(object):
         self.win.addnstr(10, 1, text, 15)
 
         # Draw the receiver info suffix fields
-        text = '{:.3f}'.format((self.center_freq)/1E6)
+        if self.freq_entry <> 'None':
+            text = self.freq_entry
+        else:
+            text = '{:.3f}'.format((self.center_freq)/1E6)
         self.win.addnstr(1, 17, text, 8, curses.color_pair(5))
         text = str(self.gain_db)
         self.win.addnstr(2, 17, text, 8, curses.color_pair(5))
@@ -450,6 +454,29 @@ class RxWindow(object):
             return True
         elif keyb == ord('j'):
             self.center_freq -= 1E5
+            return True
+        elif keyb == ord('/'):
+            # set mode to frequency entry
+            self.freq_entry = ''
+            return True
+        elif keyb == 27:
+            # end frequncy entry mode without seting the frequency
+            self.freq_entry = 'None'
+            return True
+        elif keyb == ord('\n'):
+            # set the frequency from what was entered
+            try:
+                self.center_freq = float(self.freq_entry) * 1E6
+            except:
+                pass
+            self.freq_entry = 'None'
+            return True
+        elif self.freq_entry <> 'None' and (keyb - 48 in range (10) or keyb == ord('.')):
+            # build up frequency from 1-9 and '.'
+            self.freq_entry = self.freq_entry + chr(keyb)
+            return True
+        elif keyb == 127:
+            self.freq_entry = self.freq_entry[:-1]
             return True
         else:
             return False

--- a/apps/ham2mon.py
+++ b/apps/ham2mon.py
@@ -129,7 +129,7 @@ def main(screen):
             rxwin.volume_db = scanner.volume_db
 
         # Send keystroke to lockout window and update lockout channels if True
-        if lockoutwin.proc_keyb_set_lockout(keyb):
+        if lockoutwin.proc_keyb_set_lockout(keyb) and rxwin.freq_entry == 'None':
             # Subtract 48 from ascii keyb value to obtain 0 - 9
             idx = keyb - 48
             scanner.add_lockout(idx)


### PR DESCRIPTION
I submitting this as a pull request in order to get feedback.   Currently in ham2mon the initial value of the center frequency is set via cli and one can use keyboard short cuts to move center frequency up and down.  This pull request allows user to type "/" which puts them into frequency entry mode.  They can select Enter to accept the frequency or Esc to cancel.

I wasn't sure how best to integrate this into ham2mon.  I am open to suggestions on this as well as anything else with what I did.